### PR TITLE
support lazy property input, e.g. --property equal to --property=true

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -166,6 +166,10 @@ func (a *BaseApplication) setCustomPropertiesFromArgs() {
 			if prefix == "--" {
 				kv := val[2:]
 				kvPair := strings.Split(kv, "=")
+				// --property equal to --property=true
+				if len(kvPair) == 1 {
+					kvPair = append(kvPair, "true")
+				}
 				a.SetProperty(kvPair[0], kvPair[1])
 			}
 		}

--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -137,7 +137,8 @@ func TestApp(t *testing.T) {
 }
 
 func TestBaseApplication(t *testing.T) {
-	os.Args = append(os.Args, "--app.profiles.active=local")
+
+	os.Args = append(os.Args, "--app.profiles.active=local", "--test.property")
 
 	ba := new(app.BaseApplication)
 


### PR DESCRIPTION
support lazy property input to fix below panic.

panic: runtime error: index out of range

goroutine 1 [running]:
hidevops.io/hiboot/pkg/app.(*BaseApplication).setCustomPropertiesFromArgs(0xc00011e420)
	/Users/johnd/workspace/hidevops.io/hiboot/pkg/app/application.go:169 +0x1ad
hidevops.io/hiboot/pkg/app.(*BaseApplication).Build(0xc00011e420)
	/Users/johnd/workspace/hidevops.io/hiboot/pkg/app/application.go:140 +0xb2
hidevops.io/hiboot/pkg/app/cli.(*application).build(0xc00011e420, 0x1896f40, 0xc00011e420)
	/Users/johnd/workspace/hidevops.io/hiboot/pkg/app/cli/application.go:63 +0x42
hidevops.io/hiboot/pkg/app/cli.(*application).Run(0xc00011e420)
	/Users/johnd/workspace/hidevops.io/hiboot/pkg/app/cli/application.go:108 +0x2b
main.main()
	/Users/johnd/workspace/hidevops.io/hiboot/examples/cli/advanced/main.go:30 +0x196
exit status 2