### PR TITLE
refactored auto configuration to support any name definition of the s…

### DIFF
--- a/examples/web/autoconfig/config/configuration.go
+++ b/examples/web/autoconfig/config/configuration.go
@@ -14,14 +14,14 @@ const Profile string = "config"
 
 var ErrFoo = errors.New("foo with error")
 
-type configuration struct {
+type appConfig struct {
 	at.AutoConfiguration
 
 	properties *properties
 }
 
-func newConfiguration(properties *properties) *configuration {
-	return &configuration{properties: properties}
+func newConfiguration(properties *properties) *appConfig {
+	return &appConfig{properties: properties}
 }
 
 func init() {
@@ -42,7 +42,7 @@ type Bar struct {
 }
 
 type FooBar struct {
-	at.ContextAware
+	at.Scope `value:"request"`
 
 	Name string `json:"name" value:"foobar"`
 }
@@ -58,16 +58,16 @@ type FooWithError struct {
 	Name     string `json:"name" value:"foo"`
 }
 
-func (c *configuration) FooWithError() (foo *FooWithError, err error) {
+func (c *appConfig) FooWithError() (foo *FooWithError, err error) {
 	err = ErrFoo
 	return
 }
 
-func (c *configuration) Foo() *Foo {
+func (c *appConfig) Foo() *Foo {
 	return &Foo{}
 }
 
-func (c *configuration) Bar(ctx context.Context, foobar *FooBar) *Bar {
+func (c *appConfig) Bar(ctx context.Context, foobar *FooBar) *Bar {
 	if ctx.GetHeader("Authorization") == "fake" {
 		ctx.StatusCode(http.StatusUnauthorized)
 		return nil
@@ -75,7 +75,7 @@ func (c *configuration) Bar(ctx context.Context, foobar *FooBar) *Bar {
 	return &Bar{Name: c.properties.Name, FooBarName: foobar.Name}
 }
 
-func (c *configuration) FooBar() *FooBar {
+func (c *appConfig) FooBar() *FooBar {
 	return &FooBar{}
 }
 
@@ -85,7 +85,7 @@ type BazConfig struct {
 }
 
 // Baz is a prototype scoped instance
-func (c *configuration) Baz(cfg *BazConfig) *Baz {
+func (c *appConfig) Baz(cfg *BazConfig) *Baz {
 	log.Infof("baz config: %+v", cfg)
 	return &Baz{Name: cfg.Name}
 }

--- a/examples/web/autoconfig/config/properties.go
+++ b/examples/web/autoconfig/config/properties.go
@@ -5,7 +5,7 @@ import "github.com/hidevopsio/hiboot/pkg/at"
 type properties struct {
 	at.ConfigurationProperties `value:"config"`
 
-	Enabled bool `json:"enabled" `
+	Enabled bool `json:"enabled"`
 
 	Name string `json:"name" default:"foo"`
 

--- a/pkg/factory/autoconfigure/configurable.go
+++ b/pkg/factory/autoconfigure/configurable.go
@@ -219,11 +219,22 @@ func (f *configurableFactory) Instantiate(configuration interface{}) (err error)
 	return
 }
 
-func (f *configurableFactory) parseName(item *factory.MetaData) string {
+func (f *configurableFactory) parseName(item *factory.MetaData) (name string) {
+	//first, read the annotation of at.AutoConfiguration as the name
+	ann := annotation.GetAnnotation(item.MetaObject, at.AutoConfiguration{})
+	if ann != nil {
+		var ok bool
+		name, ok = ann.Field.StructField.Tag.Lookup("value")
+		if ok {
+			return
+		}
+	}
 
-	//return item.PkgName
-	name := strings.Replace(item.TypeName, PostfixConfiguration, "", -1)
-	name = str.ToLowerCamel(name)
+	//then check the type name has PostfixConfiguration
+	if len(name) == 0 && strings.Contains(item.TypeName, PostfixConfiguration) {
+		name = strings.Replace(item.TypeName, PostfixConfiguration, "", -1)
+		name = str.ToLowerCamel(name)
+	}
 
 	if name == "" || name == strings.ToLower(PostfixConfiguration) {
 		name = item.PkgName

--- a/pkg/factory/autoconfigure/configurable_test.go
+++ b/pkg/factory/autoconfigure/configurable_test.go
@@ -369,6 +369,14 @@ func newHelloService(foo *Foo) *helloService {
 	return &helloService{foo: foo}
 }
 
+type vnsConfig struct {
+	at.AutoConfiguration `value:"venus"`
+}
+
+func newVnsConfig() *vnsConfig {
+	return &vnsConfig{}
+}
+
 func setFactory(t *testing.T, configDir string, customProperties cmap.ConcurrentMap) factory.ConfigurableFactory {
 	io.ChangeWorkDir(os.TempDir())
 
@@ -463,6 +471,7 @@ func TestConfigurableFactory(t *testing.T) {
 		factory.NewMetaData(newFoobarConfiguration),
 		factory.NewMetaData(newEarthConfiguration),
 		factory.NewMetaData(newScopedConfiguration),
+		factory.NewMetaData(newVnsConfig),
 	})
 
 	f.AppendComponent(newHelloService)

--- a/pkg/system/property_builder.go
+++ b/pkg/system/property_builder.go
@@ -402,7 +402,7 @@ func (b *propertyBuilder) Build(profiles ...string) (conf interface{}, err error
 	return
 }
 
-// Read single file
+// Load single file
 func (b *propertyBuilder) Load(properties interface{}, opts ...func(*mapstructure.DecoderConfig)) (err error) {
 	ann := annotation.GetAnnotation(properties, at.ConfigurationProperties{})
 	if ann != nil {
@@ -417,7 +417,7 @@ func (b *propertyBuilder) Load(properties interface{}, opts ...func(*mapstructur
 	return
 }
 
-// Replace replace reference and
+// Replace reference and
 func (b *propertyBuilder) Replace(source string) (retVal interface{}) {
 	result := source
 	matches := replacer.GetMatches(source)


### PR DESCRIPTION
…truct for auto configuration as long as annotation at.AutoConfiguration is embedded, use the tag name as config profile if tag  is added, or package name if it is not